### PR TITLE
Small, mostly non-functional fixes.

### DIFF
--- a/api_authenticate.py
+++ b/api_authenticate.py
@@ -13,7 +13,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiAuthenticate(object):
+class ApiAuthenticate:
     """
     A class for authentication related api calls.
     """

--- a/api_client_connectors.py
+++ b/api_client_connectors.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiClientConnectors(object):
+class ApiClientConnectors:
     """
     A class for client connector related api calls.
     """
@@ -42,8 +42,8 @@ class ApiClientConnectors(object):
         )
 
     def create(
-        self, name, interface_name, dns_hosts=[], gateway_ips=[],
-        group_ids=[], description="created by api user", tunnel=False
+        self, name, interface_name, dns_hosts=None, gateway_ips=None,
+            group_ids=None, description="created by api user", tunnel=False
     ):
         """
         Used in the creation of client connectors.
@@ -63,6 +63,9 @@ class ApiClientConnectors(object):
                 - user (dict): client connector object details.
         """
 
+        dns_hosts = dns_hosts or []
+        gateway_ips = gateway_ips or []
+        group_ids = group_ids or []
         gateway_data = {
             "interfaceName": f"{interface_name}",
             "name": f"{name}",

--- a/api_contexts.py
+++ b/api_contexts.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiContexts(object):
+class ApiContexts:
     """
     A class for context related api calls.
     """

--- a/api_groups.py
+++ b/api_groups.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiGroups(object):
+class ApiGroups:
     """
     A class for group related api calls.
     """

--- a/api_helper.py
+++ b/api_helper.py
@@ -5,7 +5,7 @@ import json
 import requests
 
 
-class ApiHelper():
+class ApiHelper:
     """
     A class for assisting other api libraries.
     """
@@ -114,7 +114,7 @@ class ApiHelper():
             else:
                 data = json.loads(data)
                 return data
-        except ValueError as e:
-            raise Exception(e)
         except json.decoder.JSONDecodeError as e:
+            raise Exception(e)
+        except ValueError as e:
             raise Exception(e)

--- a/api_idp.py
+++ b/api_idp.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiIdp(object):
+class ApiIdp:
     """
     A class for user identity related api calls.
     """

--- a/api_networks.py
+++ b/api_networks.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiNetworks(object):
+class ApiNetworks:
     """
     A class for network related api calls.
     """
@@ -60,29 +60,29 @@ class ApiNetworks(object):
             response (list(dict)): node details.
         """
 
-        sourceNobs = []
+        source_nobs = []
 
         for key, value in source_ids.items():
             if key == "user":
                 for user_id in value:
                     temp = {"id": user_id, "type": key}
-                    sourceNobs.append(temp)
+                    source_nobs.append(temp)
             elif key == "group":
                 for group_id in value:
                     temp = {"id": group_id, "type": key}
-                    sourceNobs.append(temp)
+                    source_nobs.append(temp)
 
-        targetNobs = []
+        target_nobs = []
 
         for key, value in destination_ids.items():
             if key == "user":
                 for user_id in value:
                     temp = {"id": user_id, "type": key}
-                    targetNobs.append(temp)
+                    target_nobs.append(temp)
             elif key == "group":
                 for group_id in value:
                     temp = {"id": group_id, "type": key}
-                    targetNobs.append(temp)
+                    target_nobs.append(temp)
 
         v2lan_data = {
             "isKeepConnected": f"{keep_connected}",
@@ -92,8 +92,8 @@ class ApiNetworks(object):
                 "sourceContextId": f"{context_id}"
             },
             "topology": {
-                "sourceNobs": sourceNobs,
-                "targetNobs": targetNobs,
+                "sourceNobs": source_nobs,
+                "targetNobs": target_nobs,
                 "type": "HUB"
             }
         }
@@ -122,17 +122,17 @@ class ApiNetworks(object):
             response (list(dict)): node details.
         """
 
-        sourceNobs = []
+        source_nobs = []
 
         for key, value in source_ids.items():
             if key == "user":
                 for user_id in value:
                     temp = {"id": user_id, "type": key}
-                    sourceNobs.append(temp)
+                    source_nobs.append(temp)
             elif key == "group":
                 for group_id in value:
                     temp = {"id": group_id, "type": key}
-                    sourceNobs.append(temp)
+                    source_nobs.append(temp)
 
         v2lan_data = {
             "isKeepConnected": f"{keep_connected}",
@@ -142,7 +142,7 @@ class ApiNetworks(object):
                 "sourceContextId": f"{context_id}"
             },
             "topology": {
-                "sourceNobs": sourceNobs,
+                "sourceNobs": source_nobs,
                 "type": "MESH"
             }
         }
@@ -170,7 +170,7 @@ class ApiNetworks(object):
         }
         self.session.headers.update(del_headers)
         v2lan_id = self.get(name)["v2lanId"]
-        new_url = self.url + f"/{v2lan_id}"
+        new_url = f"{self.url}/{v2lan_id}"
         response = ApiHelper().http(
             "POST", self.session, new_url
         )

--- a/api_rules.py
+++ b/api_rules.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiRules(object):
+class ApiRules:
     """
     A class for rule related api calls.
     """

--- a/api_servers.py
+++ b/api_servers.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiServers(object):
+class ApiServers:
     """
     A class for server related api calls.
     """
@@ -43,7 +43,7 @@ class ApiServers(object):
 
     def create(
         self, name, subdomain, description="created by api user",
-        hostname="", groups=[]
+        hostname="", groups=None
     ):
         """
         Used to build a server. Only name and subdomain are currently
@@ -59,6 +59,7 @@ class ApiServers(object):
         Returns:
             response (list(dict)): node details.
         """
+        groups = groups or []
 
         server_data = {
             "subdomain": f"{subdomain}",

--- a/api_users.py
+++ b/api_users.py
@@ -12,7 +12,7 @@ except KeyError:
     ApiHelper().print_env_error()
 
 
-class ApiUsers(object):
+class ApiUsers:
     """
     A class for user related api calls.
     """

--- a/cli_helper.py
+++ b/cli_helper.py
@@ -3,7 +3,7 @@
 import json
 
 
-class CliHelper():
+class CliHelper:
     """
     A class to assist with cli utility functionality.
     """


### PR DESCRIPTION
* Placed `except JSONDecodeError` above `except ValueError`, since the former is a subclass of that latter, and would never be caught in the original configuration.
* Replaced mutable default args with `None` and set the default values in the method body. (These were on as-yet unused params anyway.)
* It's not necessary to explicitly inherit from `object`.
* PEP-compliant names for `target_nob`, `source_nob` &c.